### PR TITLE
Change cert retrieval, CRL, and OCSP headers to reflect project location

### DIFF
--- a/capi/lib/certificateUtils/parseChain.go
+++ b/capi/lib/certificateUtils/parseChain.go
@@ -63,7 +63,7 @@ func GatherCertificateChain(subjectURL string) ([]*x509.Certificate, error) {
 	if err != nil {
 		return []*x509.Certificate{}, err
 	}
-	req.Header.Add("X-Automated-Tool", `https://github.com/christopher-henderson/capi CCADB test website verification tool"`)
+	req.Header.Add("X-Automated-Tool", "https://github.com/mozilla/CCADB-Tools/capi CCADB test website verification tool")
 	resp, err := client.Do(req)
 	if err != nil {
 		return []*x509.Certificate{}, err

--- a/capi/lib/revocation/crl/crl.go
+++ b/capi/lib/revocation/crl/crl.go
@@ -78,6 +78,7 @@ func newCRL(serialNumber *big.Int, distributionPoint string) (crl CRL) {
 		return
 	}
 	req, err := http.NewRequest("GET", distributionPoint, nil)
+	req.Header.Add("X-Automated-Tool", "https://github.com/mozilla/CCADB-Tools/capi CCADB test website verification tool")
 	client := http.Client{}
 	client.Timeout = time.Duration(10 * time.Second)
 	raw, err := client.Do(req)

--- a/capi/lib/revocation/ocsp/ocsp.go
+++ b/capi/lib/revocation/ocsp/ocsp.go
@@ -187,6 +187,7 @@ func newOCSPResponse(certificate, issuer *x509.Certificate, responder string) (r
 		response.Error = errors.Wrap(err, "failed to create HTTP POST for OCSP request").Error()
 		return
 	}
+	r.Header.Add("X-Automated-Tool", "https://github.com/mozilla/CCADB-Tools/capi CCADB test website verification tool")
 	r.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0")
 	r.Header.Set("Content-Type", OCSPContentType)
 	client := http.Client{}


### PR DESCRIPTION
The initial call to gather certificates were pointing to my personal repo. Additionally, OCPS and CRL requests were not indicating that they were from this tool at all.