### PR TITLE
Revert Previous Change

### DIFF
--- a/capi/lib/service/interpretation.go
+++ b/capi/lib/service/interpretation.go
@@ -67,8 +67,10 @@ func InterpretResult(result *model.TestWebsiteResult, expectation Expectation) {
 		// Root must NOT be expired.
 		result.Opinion.Append(assertNotExpired(result.Chain.Root, Root))
 		/////// Revocation checks
-		// Leaf may be either Good or Unauthorized
-		result.Opinion.Append(assertNotRevoked(result.Chain.Leaf, Leaf))
+		//
+		// By policy, we do not care whether or not the leaf certificate
+		// is revoked by any CRL or OCSP responder.
+		//
 		// Intermediates may be good (or Unauthorized iff they are expired)
 		for _, intermediate := range result.Chain.Intermediates {
 			result.Opinion.Append(assertNotRevoked(intermediate, Intermediate))
@@ -86,14 +88,12 @@ func InterpretResult(result *model.TestWebsiteResult, expectation Expectation) {
 		// Root must not be expired
 		result.Opinion.Append(assertNotExpired(result.Chain.Root, Root))
 		/////// Revocation checks
-		//
-		// By policy, we do not care whether or not the leaf certificate
-		// is revoked by any CRL or OCSP responder.
-		//
+		// Leaf MUST be revoked.
+		result.Opinion.Append(assertRevoked(result.Chain.Leaf, Leaf))
 		// Intermediates MAY be revoked
 		for _, intermediate := range result.Chain.Intermediates {
 			result.Opinion.Append(assertMayBeRevoked(intermediate, Intermediate))
-		}
+}
 		// Root must NOT be revoked
 		result.Opinion.Append(assertNotRevoked(result.Chain.Root, Root))
 	}

--- a/capi/lib/service/interpretation.go
+++ b/capi/lib/service/interpretation.go
@@ -93,7 +93,7 @@ func InterpretResult(result *model.TestWebsiteResult, expectation Expectation) {
 		// Intermediates MAY be revoked
 		for _, intermediate := range result.Chain.Intermediates {
 			result.Opinion.Append(assertMayBeRevoked(intermediate, Intermediate))
-}
+		}
 		// Root must NOT be revoked
 		result.Opinion.Append(assertNotRevoked(result.Chain.Root, Root))
 	}


### PR DESCRIPTION
This change reverts the previous change which incorrectly removed OCSP checking for the `revoked` test suite. Additionally, it correctly removes OCSP checking for the `expired` test suite.