### PR TITLE
Fix GCP

### DIFF
--- a/kinto_integrity/Rocket.toml
+++ b/kinto_integrity/Rocket.toml
@@ -1,2 +1,0 @@
-[global]
-port = 8080

--- a/kinto_integrity/src/firefox/mod.rs
+++ b/kinto_integrity/src/firefox/mod.rs
@@ -201,7 +201,9 @@ impl Firefox {
     /// Under the condition that no change has been made on the remote, then this method
     /// returns self.
     pub fn update(&mut self) -> Result<&mut Firefox> {
-        let resp = http::new_get_request(NIGHTLY.clone()).header("If-None-Match", self.etag.clone()).send()?;
+        let resp = http::new_get_request(NIGHTLY.clone())
+            .header("If-None-Match", self.etag.clone())
+            .send()?;
         if resp.status() == 304 {
             println!("{} reported no changes to Firefox", NIGHTLY.clone());
             return Ok(self);
@@ -277,7 +279,9 @@ impl TryFrom<Url> for Firefox {
             .chain_err(|| format!("The etag header from {} could not be parsed", endpoint))?
             .to_string();
         println!("Expanding to {}", home.as_ref().to_string_lossy());
-        let content_length = resp.content_length().chain_err(|| format!("Could not get a content length from {}", endpoint))?;
+        let content_length = resp
+            .content_length()
+            .chain_err(|| format!("Could not get a content length from {}", endpoint))?;
         let bar = indicatif::ProgressBar::new(content_length);
         tar::Archive::new(bzip2::bufread::BzDecoder::new(BufReader::new(
             bar.wrap_read(resp),

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -34,7 +34,6 @@ use kinto::*;
 use model::*;
 use revocations_txt::*;
 
-
 #[get("/")]
 fn default() -> Result<String> {
     let revocations: Revocations = Revocations::default()?;
@@ -86,8 +85,23 @@ fn without_revocations() -> Result<String> {
 
 fn main() -> Result<()> {
     firefox::init();
-    rocket::ignite()
-        .mount("/", routes![default, with_revocations, post_revocations, without_revocations])
+    let port = match std::env::var("PORT") {
+        Ok(port) => port.parse().unwrap(),
+        Err(_) => 8080,
+    } as u16;
+    let config = rocket::Config::build(rocket::config::Environment::Production)
+        .port(port)
+        .finalize().unwrap();
+    rocket::custom(config)
+        .mount(
+            "/",
+            routes![
+                default,
+                with_revocations,
+                post_revocations,
+                without_revocations
+            ],
+        )
         .launch();
     Ok(())
 }


### PR DESCRIPTION
Google Cloud Platform requires that you bind to the port defined by the `PORT` environment variable. Failure to do so causes the launched container to bind to a port that the upstream container is likely not routing to.