### PR TITLE
Speedup

### DIFF
--- a/kinto_integrity/Cargo.lock
+++ b/kinto_integrity/Cargo.lock
@@ -145,6 +145,17 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clicolors-control"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +390,14 @@ dependencies = [
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fern"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -629,11 +648,14 @@ version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-rkv 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "rkv 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -829,6 +851,15 @@ dependencies = [
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num-traits"
@@ -1888,6 +1919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum console 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8ca57c2c14b8a2bf3105bc9d15574aad80babf6a9c44b1058034cdf8bd169628"
@@ -1913,6 +1945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fern 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "29d26fa0f4d433d1956746e66ec10d6bf4d6c8b93cd39965cceea7f7cc78c7dd"
 "checksum filetime 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8c63033fcba1f51ef744505b3cad42510432b904c062afa67ad7ece008429d"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1959,6 +1992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
 "checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bcef43580c035376c0705c42792c294b66974abbfd2789b511784023f71f3273"
 "checksum number_prefix 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dbf9993e59c894e3c08aa1c2712914e9e6bf1fcbfc6bef283e2183df345a4fee"

--- a/kinto_integrity/Cargo.toml
+++ b/kinto_integrity/Cargo.toml
@@ -18,6 +18,10 @@ tar = "0.4"
 error-chain = "0.12.1"
 url = "2.1.0"
 
+fern = "0.5.8"
+log = "0.4"
+chrono = "0.4.7"
+
 serde_json = "1.0"
 serde =  { version = "1.0.92", features = ["derive"] }
 

--- a/kinto_integrity/Dockerfile
+++ b/kinto_integrity/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM rustlang/nightly AS buildStage
+FROM rustlang/rust:nightly AS buildStage
 
 WORKDIR /opt
 COPY . .

--- a/kinto_integrity/Dockerfile
+++ b/kinto_integrity/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM rustlang/rust:nightly AS buildStage
+FROM rustlang/rust@sha256:771b53ed3df7ee93a000a67be3307d7afe09523d4683956cb2d6e0a71b7dbf7e AS buildStage
 
 WORKDIR /opt
 COPY . .

--- a/kinto_integrity/Dockerfile
+++ b/kinto_integrity/Dockerfile
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-FROM rustlang/rust@sha256:9e9cc1a52844b762c820648d8dcfbbc2878065f3fe233f504144731c93289df9 AS buildStage
+FROM rustlang/nightly AS buildStage
 
 WORKDIR /opt
 COPY . .

--- a/kinto_integrity/README.md
+++ b/kinto_integrity/README.md
@@ -41,6 +41,8 @@ curl -X POST -H "Content-Type: text/plain" --data-binary @revocations.txt http:/
 
 > NOTE: The header `"Content-Type: text/plain"` is mandatory. Failure to set this header will result in a 404.
 
+> NOTE: This endpoint only supports the POST HTTP method. Any other method will return a 404.
+
 ### Excluding revocations.txt
 The following endpoint excludes `revocations.txt` from the computation altogether.
 ```bash
@@ -53,7 +55,8 @@ While this application polls `download.mozilla.org` each hour, as well as pollin
 curl -X PATCH http://example.org/update_firefox_nightly
 ```
 Updating Firefox Nightly also triggers a refresh of `cert_storage`
-This method *_must_* be PATCH - all other HTTP methods will return a 404.
+
+> NOTE: This endpoint only supports the PATCH HTTP method. Any other method will return a 404.
 
 ### Force Updating cert_storage
 `cert_storage` is freshed each time Firefox Nightly is updated. However, if you believe that `cert_storage` warrants an immediate refresh, then you may do so.
@@ -61,7 +64,7 @@ This method *_must_* be PATCH - all other HTTP methods will return a 404.
 curl -X PATCH http://example.org/update_cert_storage
 ```
 
-This method *_must_* be PATCH - all other HTTP methods will return a 404.
+> NOTE: This endpoint only supports the PATCH HTTP method. Any other method will return a 404.
 
 ### Return Structures
 

--- a/kinto_integrity/src/errors/mod.rs
+++ b/kinto_integrity/src/errors/mod.rs
@@ -2,7 +2,11 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use rocket::http::Status;
+use rocket::response::{Responder, ResponseBuilder};
+use rocket::{Request, Response};
 use std::convert::From;
+use std::io::Cursor;
 
 error_chain! {
     foreign_links {
@@ -17,5 +21,14 @@ error_chain! {
 impl std::convert::From<rkv::StoreError> for Error {
     fn from(err: rkv::StoreError) -> Self {
         format!("{:?}", err).into()
+    }
+}
+
+impl<'a> Responder<'a> for Error {
+    fn respond_to(self, _: &Request) -> std::result::Result<Response<'a>, Status> {
+        Ok(ResponseBuilder::new(Response::new())
+            .sized_body(Cursor::new(self.to_string()))
+            .status(Status::InternalServerError)
+            .finalize())
     }
 }

--- a/kinto_integrity/src/firefox/cert_storage/mod.rs
+++ b/kinto_integrity/src/firefox/cert_storage/mod.rs
@@ -38,9 +38,10 @@ impl TryFrom<PathBuf> for CertStorage {
         let reader = env.read()?;
         for item in store.iter_start(&reader)? {
             let (key, value) = item?;
-            let is = match key {
-                [b'i', b's', k..] => decode_revocation(k, &value),
-                [..] => None,
+            let is = if key.starts_with(&vec![b'i', b's']) && key.len() > 2 {
+                decode_revocation(&key[2..key.len()], &value)
+            } else {
+                None
             };
             match is {
                 Some(Ok(issuer_serial)) => {

--- a/kinto_integrity/src/firefox/cert_storage/mod.rs
+++ b/kinto_integrity/src/firefox/cert_storage/mod.rs
@@ -25,11 +25,10 @@ pub struct IssuerSerial {
 impl TryFrom<PathBuf> for CertStorage {
     type Error = Error;
 
-    fn try_from(mut db_path: PathBuf) -> Result<Self> {
+    fn try_from(db_path: PathBuf) -> Result<Self> {
         let mut revocations = CertStorage {
             data: HashSet::new(),
         };
-        db_path.push("security_state");
         let mut builder = Rkv::environment_builder();
         builder.set_max_dbs(2);
         builder.set_flags(EnvironmentFlags::READ_ONLY);

--- a/kinto_integrity/src/firefox/mod.rs
+++ b/kinto_integrity/src/firefox/mod.rs
@@ -52,7 +52,10 @@ const CERT_STORAGE_POPULATION_TIMEOUT: u64 = 30; // seconds
 const CERT_STORAGE_POPULATION_HEURISTIC: u64 = 10; // ticks
 
 pub fn init() {
-    info!("Starting the X Virtual Frame Buffer on DISPLAY={}", xvfb::DISPLAY_PORT);
+    info!(
+        "Starting the X Virtual Frame Buffer on DISPLAY={}",
+        xvfb::DISPLAY_PORT
+    );
     let _ = *XVFB;
     info!("Initializing Firefox Nightly");
     let _ = *FIREFOX;
@@ -91,7 +94,10 @@ pub struct Firefox {
 
 impl Drop for Firefox {
     fn drop(&mut self) {
-        info!("Deleting Firefox located at {}", self._home.path().to_string_lossy());
+        info!(
+            "Deleting Firefox located at {}",
+            self._home.path().to_string_lossy()
+        );
     }
 }
 
@@ -217,6 +223,7 @@ impl Firefox {
         Ok(())
     }
 
+    /// Completely ignores the etag header and forces and download of Firefox.
     pub fn force_update(&mut self) -> Result<()> {
         let resp = http::new_get_request(NIGHTLY.clone()).send()?;
         let new_ff = resp.try_into()?;
@@ -224,6 +231,7 @@ impl Firefox {
         Ok(())
     }
 
+    /// Creates a new profile with a freshly populated cert_storage.
     pub fn update_cert_storage(&mut self) -> Result<()> {
         self.profile = Profile::new()?;
         self.create_profile()
@@ -274,6 +282,7 @@ impl TryFrom<&str> for Firefox {
     }
 }
 
+/// Creates a Firefox instance from the given Url.
 impl TryFrom<Url> for Firefox {
     type Error = Error;
 
@@ -282,6 +291,7 @@ impl TryFrom<Url> for Firefox {
     }
 }
 
+/// Response is expected to be a stream of tar.bzip archive of Firefox.
 impl TryFrom<Response> for Firefox {
     type Error = Error;
 

--- a/kinto_integrity/src/firefox/mod.rs
+++ b/kinto_integrity/src/firefox/mod.rs
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use reqwest::Url;
+use reqwest::{Url, Response};
 use std::convert::{TryFrom, TryInto};
 
 use tempdir::TempDir;
@@ -14,12 +14,11 @@ use crate::firefox::profile::Profile;
 use std::ffi::OsString;
 use std::io::BufReader;
 use std::process::{Child, Command, Stdio};
-use std::sync::Mutex;
+use std::sync::RwLock;
 use std::time::Duration;
 
 use crate::firefox::cert_storage::CertStorage;
 use crate::http;
-use std::path::Path;
 use xvfb::Xvfb;
 
 pub mod cert_storage;
@@ -32,7 +31,7 @@ lazy_static! {
         "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
             .parse()
             .unwrap();
-    pub static ref FIREFOX: Mutex<Firefox> = Mutex::new((*NIGHTLY).clone().try_into().unwrap());
+    pub static ref FIREFOX: RwLock<Firefox> = RwLock::new((*NIGHTLY).clone().try_into().unwrap());
     static ref XVFB: Xvfb = Xvfb::new().unwrap();
 }
 
@@ -67,7 +66,7 @@ pub fn init() {
     std::thread::spawn(|| {
         std::thread::sleep(Duration::from_secs(60 * 60));
         println!("Scheduled Firefox update triggered.");
-        match FIREFOX.lock() {
+        match FIREFOX.write() {
             Ok(mut ff) => match ff.update() {
                 Ok(_) => (),
                 Err(err) => eprintln!("{:?}", err),
@@ -90,25 +89,18 @@ impl Drop for DroppableChild {
 }
 
 pub struct Firefox {
-    home: TempDir,
+    _home: TempDir,
     executable: OsString,
-    pub etag: String,
+    profile: Profile,
+    etag: String,
 }
 
 impl Firefox {
     pub fn default() -> Result<CertStorage> {
-        let profile = match FIREFOX.lock() {
+        match FIREFOX.read() {
             Err(err) => Err(format!("{:?}", err))?,
-            Ok(mut ff) => ff
-                .update()
-                .chain_err(|| "failed to update Firefox Nightly")?
-                .create_profile()
-                .chain_err(|| "failed to create a profile for Firefox Nightly")?,
-        };
-        Path::new(&profile.home)
-            .to_path_buf()
-            .try_into()
-            .chain_err(|| "failed to parse cert_storage")
+            Ok(ff) => ff.profile.cert_storage().chain_err(|| "failed to parse cert_storage")
+        }
     }
 
     /// Creates and initializes a new profile managed by this instance of Firefox.
@@ -116,43 +108,41 @@ impl Firefox {
     /// Note that profile creation entails the spinning of a file watcher for cert_storage.
     /// We receive no explicit declaration of cert_storage initalization from Firefox, so
     /// we have to simply watch the file and wait for it to stop growing in size.
-    pub fn create_profile(&self) -> Result<Profile> {
-        // Creates a name and system tmp directory for our profile.
-        let profile = Profile::new()?;
+    fn create_profile(&self) -> Result<()> {
         // Register the profile with Firefox.
-        println!("Creating profile {} at {}", profile.name, profile.home);
+        println!("Creating profile {} at {}", self.profile.name, self.profile.home);
         self.cmd()
-            .args(Firefox::create_profile_args(&profile))
+            .args(self.create_profile_args())
             .output()
             .chain_err(|| "failed to create a profile for Firefox Nightly")?;
         // Startup Firefox with the given profile. Doing so will initialize the entire
         // profile to a fresh state and begin populating the cert_storage database.
-        println!("Initializing profile {} at {}", profile.name, profile.home);
+        println!("Initializing profile {} at {}", self.profile.name, self.profile.home);
         let _cmd = DroppableChild {
             child: self
                 .cmd()
-                .args(Firefox::init_profile_args(&profile))
+                .args(self.init_profile_args())
                 .spawn()
                 .chain_err(|| {
                     format!(
                         "failed to start Firefox Nightly in the context of the profile at {}",
-                        profile.home
+                        self.profile.home
                     )
                 })?,
         };
         // Unfortunately, it's not like Firefox is giving us update progress over stdout,
         // so in order to be notified if cert storage is done being populate we gotta
         // listen in on the file and check up on its size.
-        let database = || std::fs::metadata(profile.cert_storage());
+        let database = || std::fs::metadata(self.profile.cert_storage_path());
         // Spin until it's created.
-        let cert_storage_name = profile.cert_storage().to_string_lossy().into_owned();
+        let cert_storage_name = self.profile.cert_storage_path().to_string_lossy().into_owned();
         println!("Waiting for {} to be created.", cert_storage_name);
         let mut initial_size;
         let start = std::time::Instant::now();
         loop {
             std::thread::sleep(Duration::from_millis(100));
             if start.elapsed() == Duration::from_secs(PROFILE_CREATION_TIMEOUT) {
-                return Err(format!("Firefox Nightly timed out by taking more than ten seconds to initialize the profile at {}", profile.home).into());
+                return Err(format!("Firefox Nightly timed out by taking more than ten seconds to initialize the profile at {}", self.profile.home).into());
             }
             match database() {
                 Err(_) => (),
@@ -193,50 +183,34 @@ impl Firefox {
             }
             std::thread::sleep(Duration::from_millis(500));
         }
-        Ok(profile)
+        Ok(())
     }
 
     /// Attempts to consume this instance of Firefox and replace it with a possible update.
     ///
     /// Under the condition that no change has been made on the remote, then this method
     /// returns self.
-    pub fn update(&mut self) -> Result<&mut Firefox> {
+    pub fn update(&mut self) -> Result<()> {
         let resp = http::new_get_request(NIGHTLY.clone())
             .header("If-None-Match", self.etag.clone())
             .send()?;
         if resp.status() == 304 {
             println!("{} reported no changes to Firefox", NIGHTLY.clone());
-            return Ok(self);
+            return Ok(());
         }
         println!("{} claims an update to Firefox", NIGHTLY.clone());
-        let home = TempDir::new("kinto_integrity_firefox_nightly")?;
-        let executable = home.path().join("firefox").join("firefox").into_os_string();
-        let etag = match resp.headers().get("etag") {
-            Some(etag) => match etag.to_str() {
-                Ok(string) => string.to_string(),
-                Err(err) => return Err(Error::from(err.to_string())),
-            },
-            None => {
-                return Err(Error::from(format!(
-                    "no etag header was present in a request to {}",
-                    *NIGHTLY
-                )))
-            }
-        };
-        tar::Archive::new(bzip2::bufread::BzDecoder::new(BufReader::new(resp))).unpack(&home)?;
-        self.home = home;
-        self.executable = executable;
-        self.etag = etag;
-        Ok(self)
+        let new_ff = resp.try_into()?;
+        std::mem::replace(self, new_ff);
+        Ok(())
     }
 
     /// Generates the arguments to fulfill:
     ///     ./firefox -CreateProfile "profile_name profile_dir"
     /// See https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#-CreateProfile_.22profile_name_profile_dir.22
-    fn create_profile_args(profile: &Profile) -> Vec<String> {
+    fn create_profile_args(&self) -> Vec<String> {
         vec![
             CREATE_PROFILE.to_string(),
-            format!(r#"{} {}"#, profile.name, profile.home),
+            format!(r#"{} {}"#, self.profile.name, self.profile.home),
         ]
     }
 
@@ -248,8 +222,8 @@ impl Firefox {
     /// to Kinto. The result being that you can startup, and initialize, the profile but
     /// you have to wait around and watch the profile for changes to see if cert_storage
     /// is finished populating.
-    fn init_profile_args(profile: &Profile) -> Vec<String> {
-        vec![WITH_PROFILE.to_string(), profile.home.clone()]
+    fn init_profile_args(&self) -> Vec<String> {
+        vec![WITH_PROFILE.to_string(), self.profile.home.clone()]
     }
 
     /// Returns a Command which is partially pre-built with the more fiddly bits of
@@ -259,39 +233,6 @@ impl Firefox {
         cmd.env(NULL_DISPLAY_ENV.0, NULL_DISPLAY_ENV.1);
         cmd.stdout(Stdio::null());
         cmd
-    }
-}
-
-impl TryFrom<Url> for Firefox {
-    type Error = Error;
-
-    fn try_from(value: Url) -> Result<Self> {
-        let endpoint = value.to_string();
-        println!("Downloading {}", endpoint);
-        let home = TempDir::new("")?;
-        let executable = home.path().join("firefox").join("firefox").into_os_string();
-        let resp = http::new_get_request(value).send()?;
-        let etag = resp
-            .headers()
-            .get("etag")
-            .chain_err(|| format!("No etag header was present in a request to {}", endpoint))?
-            .to_str()
-            .chain_err(|| format!("The etag header from {} could not be parsed", endpoint))?
-            .to_string();
-        println!("Expanding to {}", home.as_ref().to_string_lossy());
-        let content_length = resp
-            .content_length()
-            .chain_err(|| format!("Could not get a content length from {}", endpoint))?;
-        let bar = indicatif::ProgressBar::new(content_length);
-        tar::Archive::new(bzip2::bufread::BzDecoder::new(BufReader::new(
-            bar.wrap_read(resp),
-        )))
-        .unpack(&home)?;
-        Ok(Firefox {
-            home,
-            executable,
-            etag,
-        })
     }
 }
 
@@ -307,6 +248,48 @@ impl TryFrom<&str> for Firefox {
     }
 }
 
+impl TryFrom<Url> for Firefox {
+    type Error = Error;
+
+    fn try_from(value: Url) -> Result<Self> {
+        http::new_get_request(value).send()?.try_into()
+    }
+}
+
+impl TryFrom<Response> for Firefox {
+    type Error = Error;
+
+    fn try_from(resp: Response) -> Result<Self> {
+        let _home = TempDir::new("")?;
+        let executable = _home.path().join("firefox").join("firefox").into_os_string();
+        let etag = resp
+            .headers()
+            .get("etag")
+            .chain_err(|| format!("No etag header was present in a request to {}", resp.url()))?
+            .to_str()
+            .chain_err(|| format!("The etag header from {} could not be parsed", resp.url()))?
+            .to_string();
+        println!("Expanding to {}", _home.as_ref().to_string_lossy());
+        let content_length = resp
+            .content_length()
+            .chain_err(|| format!("Could not get a content length from {}", resp.url()))?;
+        let bar = indicatif::ProgressBar::new(content_length);
+        tar::Archive::new(bzip2::bufread::BzDecoder::new(BufReader::new(
+            bar.wrap_read(resp),
+        )))
+        .unpack(&_home)?;
+        let profile = Profile::new()?;
+        let ff = Firefox {
+            _home,
+            executable,
+            profile,
+            etag,
+        };
+        ff.create_profile()?;
+        Ok(ff)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,5 +299,4 @@ mod tests {
     fn smoke() {
         let _: Firefox = (*NIGHTLY).clone().try_into().unwrap();
     }
-
 }

--- a/kinto_integrity/src/firefox/mod.rs
+++ b/kinto_integrity/src/firefox/mod.rs
@@ -217,7 +217,7 @@ impl Firefox {
         Ok(())
     }
 
-    pub fn udpate_cert_storage(&mut self) -> Result<()> {
+    pub fn update_cert_storage(&mut self) -> Result<()> {
         self.profile = Profile::new()?;
         self.create_profile()
     }

--- a/kinto_integrity/src/firefox/mod.rs
+++ b/kinto_integrity/src/firefox/mod.rs
@@ -217,6 +217,13 @@ impl Firefox {
         Ok(())
     }
 
+    pub fn force_update(&mut self) -> Result<()> {
+        let resp = http::new_get_request(NIGHTLY.clone()).send()?;
+        let new_ff = resp.try_into()?;
+        std::mem::replace(self, new_ff);
+        Ok(())
+    }
+
     pub fn update_cert_storage(&mut self) -> Result<()> {
         self.profile = Profile::new()?;
         self.create_profile()

--- a/kinto_integrity/src/firefox/profile/mod.rs
+++ b/kinto_integrity/src/firefox/profile/mod.rs
@@ -32,12 +32,14 @@ impl Profile {
     }
 
     pub fn cert_storage(&self) -> Result<CertStorage> {
-        self.cert_storage_path().try_into()
+        self.security_state().try_into()
+    }
+
+    pub fn security_state(&self) -> PathBuf {
+        Path::new(&self.home).join(CERT_STORAGE_DIR)
     }
 
     pub fn cert_storage_path(&self) -> PathBuf {
-        Path::new(&self.home)
-            .join(CERT_STORAGE_DIR)
-            .join(CERT_STORAGE_DB)
+        self.security_state().join(CERT_STORAGE_DB)
     }
 }

--- a/kinto_integrity/src/firefox/profile/mod.rs
+++ b/kinto_integrity/src/firefox/profile/mod.rs
@@ -5,6 +5,8 @@
 use crate::errors::*;
 use std::path::{Path, PathBuf};
 use tempdir::TempDir;
+use crate::firefox::cert_storage::CertStorage;
+use std::convert::TryInto;
 
 const TMP_PREFIX: &str = "kinto_integrity_profile";
 const CERT_STORAGE_DIR: &str = "security_state";
@@ -29,7 +31,11 @@ impl Profile {
         Ok(Profile { name, home, _tmp })
     }
 
-    pub fn cert_storage(&self) -> PathBuf {
+    pub fn cert_storage(&self) -> Result<CertStorage> {
+        self.cert_storage_path().try_into()
+    }
+
+    pub fn cert_storage_path(&self) -> PathBuf {
         Path::new(&self.home)
             .join(CERT_STORAGE_DIR)
             .join(CERT_STORAGE_DB)

--- a/kinto_integrity/src/firefox/profile/mod.rs
+++ b/kinto_integrity/src/firefox/profile/mod.rs
@@ -18,6 +18,12 @@ pub struct Profile {
     _tmp: TempDir,
 }
 
+impl Drop for Profile {
+    fn drop(&mut self) {
+        info!("Deleting Firefox located at {}", self._tmp.path().to_string_lossy());
+    }
+}
+
 impl Profile {
     pub fn new() -> Result<Profile> {
         let name = format!("{:x}", rand::random::<u64>());

--- a/kinto_integrity/src/firefox/profile/mod.rs
+++ b/kinto_integrity/src/firefox/profile/mod.rs
@@ -3,10 +3,10 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::errors::*;
-use std::path::{Path, PathBuf};
-use tempdir::TempDir;
 use crate::firefox::cert_storage::CertStorage;
 use std::convert::TryInto;
+use std::path::{Path, PathBuf};
+use tempdir::TempDir;
 
 const TMP_PREFIX: &str = "kinto_integrity_profile";
 const CERT_STORAGE_DIR: &str = "security_state";

--- a/kinto_integrity/src/firefox/profile/mod.rs
+++ b/kinto_integrity/src/firefox/profile/mod.rs
@@ -20,7 +20,7 @@ pub struct Profile {
 
 impl Drop for Profile {
     fn drop(&mut self) {
-        info!("Deleting Firefox located at {}", self._tmp.path().to_string_lossy());
+        info!("Deleting Firefox profile located at {}", self._tmp.path().to_string_lossy());
     }
 }
 

--- a/kinto_integrity/src/firefox/profile/mod.rs
+++ b/kinto_integrity/src/firefox/profile/mod.rs
@@ -20,7 +20,10 @@ pub struct Profile {
 
 impl Drop for Profile {
     fn drop(&mut self) {
-        info!("Deleting Firefox profile located at {}", self._tmp.path().to_string_lossy());
+        info!(
+            "Deleting Firefox profile located at {}",
+            self._tmp.path().to_string_lossy()
+        );
     }
 }
 

--- a/kinto_integrity/src/firefox/xvfb/mod.rs
+++ b/kinto_integrity/src/firefox/xvfb/mod.rs
@@ -25,9 +25,10 @@ impl Xvfb {
 
 impl Drop for Xvfb {
     fn drop(&mut self) {
+        info!("Stopping the Xvfb server");
         match self.process.kill() {
             Ok(_) => (),
-            Err(err) => eprintln!("{:?}", err),
+            Err(err) => error!("{:?}", err),
         };
     }
 }

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -138,7 +138,8 @@ fn main() -> Result<()> {
                 with_revocations,
                 post_revocations,
                 without_revocations,
-                update_cert_storage
+                update_cert_storage,
+                update_firefox_nightly
             ],
         )
         .launch();

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -40,7 +40,7 @@ fn default() -> Result<String> {
     let kinto: Kinto = Kinto::default()?;
     let cert_storage = Firefox::default()?;
     let result: Return = (cert_storage, kinto, revocations).into();
-    Ok(serde_json::to_string(&result)?)
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 #[get("/with_revocations?<url>")]
@@ -63,7 +63,7 @@ fn with_revocations(url: &RawStr) -> Result<String> {
     let kinto: Kinto = Kinto::default()?;
     let cert_storage = Firefox::default()?;
     let result: Return = (cert_storage, kinto, revocations).into();
-    Ok(serde_json::to_string(&result)?)
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 #[post("/with_revocations", format = "text/plain", data = "<revocations_txt>")]
@@ -72,7 +72,7 @@ fn post_revocations(revocations_txt: Data) -> Result<String> {
     let kinto: Kinto = Kinto::default()?;
     let cert_storage = Firefox::default()?;
     let result: Return = (cert_storage, kinto, revocations).into();
-    Ok(serde_json::to_string(&result)?)
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 #[get("/without_revocations")]
@@ -80,7 +80,7 @@ fn without_revocations() -> Result<String> {
     let kinto: Kinto = Kinto::default()?;
     let cert_storage = Firefox::default()?;
     let result: Return = (cert_storage, kinto).into();
-    Ok(serde_json::to_string(&result)?)
+    Ok(serde_json::to_string_pretty(&result)?)
 }
 
 #[post("/update_cert_storage")]

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -84,13 +84,19 @@ fn without_revocations() -> Result<String> {
 }
 
 #[post("/update_cert_storage")]
-fn update_cert_storage() {
-    FIREFOX.write().unwrap().update_cert_storage().unwrap();
+fn update_cert_storage() -> Result<()> {
+    match FIREFOX.write() {
+        Ok(mut ff) => ff.update_cert_storage(),
+        Err(err) => Err(Error::from(format!("{}", err))),
+    }
 }
 
 #[post("/update_firefox_nightly")]
-fn update_firefox_nightly() {
-    FIREFOX.write().unwrap().force_update().unwrap();
+fn update_firefox_nightly() -> Result<()> {
+    match FIREFOX.write() {
+        Ok(mut ff) => ff.force_update(),
+        Err(err) => Err(Error::from(format!("{}", err))),
+    }
 }
 
 #[macro_use]

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -101,7 +101,9 @@ fn init_logging() {
                 message
             ))
         })
-        .level(log::LevelFilter::Debug)
+        .level_for("kinto_integrity", log::LevelFilter::Debug)
+        .level_for("hyper", log::LevelFilter::Error)
+        .level_for("tokio", log::LevelFilter::Error)
         .chain(std::io::stdout())
         .apply()
         .unwrap();

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -104,6 +104,7 @@ fn init_logging() {
         .level(log::LevelFilter::Off)
         .level_for("kinto_integrity", log::LevelFilter::Debug)
         .level_for("rocket", log::LevelFilter::Debug)
+        .level_for("_", log::LevelFilter::Debug)
         .level_for("hyper", log::LevelFilter::Error)
         .level_for("tokio", log::LevelFilter::Error)
         .level_for("tokio_reactor", log::LevelFilter::Error)

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -83,7 +83,32 @@ fn without_revocations() -> Result<String> {
     Ok(serde_json::to_string(&result)?)
 }
 
+#[post("/update_cert_storage")]
+fn update_cert_storage() {
+    FIREFOX.write().unwrap().udpate_cert_storage().unwrap();
+}
+#[macro_use]
+extern crate log;
+
+fn init_logging() {
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            out.finish(format_args!(
+                "{}[{}][{}] {}",
+                chrono::Local::now().format("[%Y-%m-%d][%H:%M:%S]"),
+                record.target(),
+                record.level(),
+                message
+            ))
+        })
+        .level(log::LevelFilter::Debug)
+        .chain(std::io::stdout())
+        .apply()
+        .unwrap();
+}
+
 fn main() -> Result<()> {
+    init_logging();
     firefox::init();
     let port = match std::env::var("PORT") {
         Ok(port) => port.parse().unwrap(),
@@ -100,7 +125,8 @@ fn main() -> Result<()> {
                 default,
                 with_revocations,
                 post_revocations,
-                without_revocations
+                without_revocations,
+                update_cert_storage
             ],
         )
         .launch();

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -91,7 +91,8 @@ fn main() -> Result<()> {
     } as u16;
     let config = rocket::Config::build(rocket::config::Environment::Production)
         .port(port)
-        .finalize().unwrap();
+        .finalize()
+        .unwrap();
     rocket::custom(config)
         .mount(
             "/",

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -90,7 +90,7 @@ fn update_cert_storage() {
 
 #[post("/update_firefox_nightly")]
 fn update_firefox_nightly() {
-    FIREFOX.write().unwrap().update().unwrap();
+    FIREFOX.write().unwrap().force_update().unwrap();
 }
 
 #[macro_use]

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -83,7 +83,7 @@ fn without_revocations() -> Result<String> {
     Ok(serde_json::to_string_pretty(&result)?)
 }
 
-#[post("/update_cert_storage")]
+#[patch("/update_cert_storage")]
 fn update_cert_storage() -> Result<()> {
     match FIREFOX.write() {
         Ok(mut ff) => ff.update_cert_storage(),
@@ -91,7 +91,7 @@ fn update_cert_storage() -> Result<()> {
     }
 }
 
-#[post("/update_firefox_nightly")]
+#[patch("/update_firefox_nightly")]
 fn update_firefox_nightly() -> Result<()> {
     match FIREFOX.write() {
         Ok(mut ff) => ff.force_update(),

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -104,6 +104,7 @@ fn init_logging() {
         .level_for("kinto_integrity", log::LevelFilter::Debug)
         .level_for("hyper", log::LevelFilter::Error)
         .level_for("tokio", log::LevelFilter::Error)
+        .level_for("tokio_reactor", log::LevelFilter::Error)
         .chain(std::io::stdout())
         .apply()
         .unwrap();

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -103,6 +103,7 @@ fn init_logging() {
         })
         .level(log::LevelFilter::Off)
         .level_for("kinto_integrity", log::LevelFilter::Debug)
+        .level_for("rocket", log::LevelFilter::Info)
         .level_for("hyper", log::LevelFilter::Error)
         .level_for("tokio", log::LevelFilter::Error)
         .level_for("tokio_reactor", log::LevelFilter::Error)

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -85,8 +85,14 @@ fn without_revocations() -> Result<String> {
 
 #[post("/update_cert_storage")]
 fn update_cert_storage() {
-    FIREFOX.write().unwrap().udpate_cert_storage().unwrap();
+    FIREFOX.write().unwrap().update_cert_storage().unwrap();
 }
+
+#[post("/update_firefox_nightly")]
+fn update_firefox_nightly() {
+    FIREFOX.write().unwrap().update().unwrap();
+}
+
 #[macro_use]
 extern crate log;
 

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -101,6 +101,7 @@ fn init_logging() {
                 message
             ))
         })
+        .level(log::LevelFilter::Off)
         .level_for("kinto_integrity", log::LevelFilter::Debug)
         .level_for("hyper", log::LevelFilter::Error)
         .level_for("tokio", log::LevelFilter::Error)

--- a/kinto_integrity/src/main.rs
+++ b/kinto_integrity/src/main.rs
@@ -103,7 +103,7 @@ fn init_logging() {
         })
         .level(log::LevelFilter::Off)
         .level_for("kinto_integrity", log::LevelFilter::Debug)
-        .level_for("rocket", log::LevelFilter::Info)
+        .level_for("rocket", log::LevelFilter::Debug)
         .level_for("hyper", log::LevelFilter::Error)
         .level_for("tokio", log::LevelFilter::Error)
         .level_for("tokio_reactor", log::LevelFilter::Error)

--- a/kinto_integrity/src/model/mod.rs
+++ b/kinto_integrity/src/model/mod.rs
@@ -67,7 +67,12 @@ impl From<WithRevocations> for Return {
                     .cloned()
                     .collect::<Vec<Intermediary>>(),
             ),
-            in_kinto_not_in_revocations: None,
+            in_kinto_not_in_revocations: Some(
+                kinto
+                    .difference(&revocations)
+                    .cloned()
+                    .collect::<Vec<Intermediary>>(),
+            ),
         }
     }
 }


### PR DESCRIPTION
This change moves cert_storage from being refreshed up on every request                                            to only being refreshed when Firefox Nightly is updated, thus greatly                                                   improving the per-request response times. Additional endpoints have been                                                added to force an update to Firefox Nightly or cert_storage if desired.  