### PR TITLE
Point CAPI to a forked version of x509lint

### DIFF
--- a/capi/Dockerfile
+++ b/capi/Dockerfile
@@ -17,7 +17,6 @@ RUN apt-get install -y libnss3-tools libssl-dev ruby-dev
 RUN go build capi.go
 RUN git clone https://github.com/christopher-henderson/x509lint.git && \
     cd x509lint && \
-    git checkout type && \
     make
 #RUN git clone https://github.com/kroeckx/x509lint.git && \
 #    cd x509lint && \

--- a/capi/Dockerfile
+++ b/capi/Dockerfile
@@ -15,9 +15,13 @@ ENV CGO_ENABLED=0
 RUN apt-get update
 RUN apt-get install -y libnss3-tools libssl-dev ruby-dev
 RUN go build capi.go
-RUN git clone https://github.com/kroeckx/x509lint.git && \
+RUN git clone https://github.com/christopher-henderson/x509lint.git && \
     cd x509lint && \
+    git checkout type && \
     make
+#RUN git clone https://github.com/kroeckx/x509lint.git && \
+#    cd x509lint && \
+#    make
 
 FROM alpine:latest
 

--- a/capi/lib/lint/x509lint/x509lint.go
+++ b/capi/lib/lint/x509lint/x509lint.go
@@ -92,7 +92,7 @@ func Lint(certificate *x509.Certificate, ctype certType) (X509Lint, error) {
 		return result, err
 	}
 	if cmderr != nil {
-		errStr := fmt.Sprintf("%s: %s %s %s %s", cmderr, string(errors), "x509lint", f.Name(), certTypeToStr[ctype])
+		errStr := fmt.Sprintf("%s, stderr: %s, stdout: %s, cmd: %s %s %s", cmderr, string(errors), string(output), "x509lint", f.Name(), certTypeToStr[ctype])
 		result.CmdError = &errStr
 		// This has the slight distinction of being an error
 		// from x509lint itself rather than from, say,

--- a/capi/lib/lint/x509lint/x509lint.go
+++ b/capi/lib/lint/x509lint/x509lint.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -81,10 +82,7 @@ func Lint(certificate *x509.Certificate, ctype certType) (X509Lint, error) {
 	stderr := bytes.NewBuffer([]byte{})
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	err = cmd.Run()
-	if err != nil {
-		return result, err
-	}
+	cmderr := cmd.Run()
 	output, err := ioutil.ReadAll(stdout)
 	if err != nil {
 		return result, err
@@ -93,12 +91,12 @@ func Lint(certificate *x509.Certificate, ctype certType) (X509Lint, error) {
 	if err != nil {
 		return result, err
 	}
-	if string(errors) != "" {
-		errStr := string(errors)
+	if cmderr != nil {
+		errStr := fmt.Sprintf("%s: %s", cmderr, string(errors))
 		result.CmdError = &errStr
 		// This has the slight distinction of being an error
 		// from x509lint itself rather than from, say,
-		// the filesystem failing.
+		// the filesystem or shell failing.
 		return result, nil
 	}
 	parseOutput(output, &result)

--- a/capi/lib/lint/x509lint/x509lint.go
+++ b/capi/lib/lint/x509lint/x509lint.go
@@ -92,7 +92,7 @@ func Lint(certificate *x509.Certificate, ctype certType) (X509Lint, error) {
 		return result, err
 	}
 	if cmderr != nil {
-		errStr := fmt.Sprintf("%s: %s", cmderr, string(errors))
+		errStr := fmt.Sprintf("%s: %s %s %s %s", cmderr, string(errors), "x509lint", f.Name(), certTypeToStr[ctype])
 		result.CmdError = &errStr
 		// This has the slight distinction of being an error
 		// from x509lint itself rather than from, say,


### PR DESCRIPTION
x509Lint supports the concept of different types of certificates (leaf, intermediate, root) however it is hardcoded to only go down the leaf checking path. We have submitted a pull request to fix this in X509lint, however in the meantime we can point the tool to the forked repo that has the fix.