### PR TITLE
Removed declaration of OCSP URL(s)

### DIFF
--- a/kinto_integrity/src/ccadb/mod.rs
+++ b/kinto_integrity/src/ccadb/mod.rs
@@ -166,8 +166,6 @@ pub struct CCADBEntry {
     pub crl_urls: String,
     #[serde(alias = "Alternate CRL")]
     pub alternate_crl: String,
-    #[serde(alias = "OCSP URL(s)")]
-    pub ocsp_urls: String,
     #[serde(alias = "Comments")]
     pub comments: String,
     #[serde(alias = "PEM Info")]


### PR DESCRIPTION
The CCADB report no longer includes the header for OCSP URLs.