### PR TITLE
Allow for a list of CRLs to attempt

### DIFF
--- a/crlVerification/main.go
+++ b/crlVerification/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Input struct {
-	Crl    []string
+	Crls   []string
 	Serial *big.Int
 	Date   time.Time
 	Reason utils.RevocationReason
@@ -29,7 +29,7 @@ type Input struct {
 
 func NewInput() Input {
 	return Input{
-		Crl:    make([]string, 0),
+		Crls:   make([]string, 0),
 		Serial: nil,
 		Date:   time.Time{},
 		Reason: utils.NOT_GIVEN,
@@ -50,7 +50,7 @@ func (i *Input) UnmarshalJSON(data []byte) error {
 			for _, crlInterface := range t {
 				switch crl := crlInterface.(type) {
 				case string:
-					i.Crl = append(i.Crl, crl)
+					i.Crls = append(i.Crls, crl)
 				default:
 					i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%v"`, crl, crl)))
 				}
@@ -58,7 +58,7 @@ func (i *Input) UnmarshalJSON(data []byte) error {
 		case string:
 			// The old interface was built for
 			// only one CRL, so let's honor that just in case
-			i.Crl = append(i.Crl, t)
+			i.Crls = append(i.Crls, t)
 		case nil:
 			// The old interface allowed for a null entry
 			// so let's leave that in place by leaving the array empty.
@@ -146,13 +146,13 @@ func NewReturn() Return {
 }
 
 func Validate(i Input) Return {
-	if len(i.Crl) == 0 {
+	if len(i.Crls) == 0 {
 		ret := NewReturn()
 		ret.Errors = append(ret.Errors, utils.CRLNotGiven{})
 		return ret
 	}
 	allErrors := make([]error, 0)
-	for _, c := range i.Crl {
+	for _, c := range i.Crls {
 		crl, err := utils.CRLFromURL(c)
 		switch err == nil {
 		case true:

--- a/crlVerification/main.go
+++ b/crlVerification/main.go
@@ -52,15 +52,18 @@ func (i *Input) UnmarshalJSON(data []byte) error {
 				case string:
 					i.Crl = append(i.Crl, crl)
 				default:
-					i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%s"`, crl, crl)))
+					i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%v"`, crl, crl)))
 				}
 			}
 		case string:
-			// The old interface allowed was built for
+			// The old interface was built for
 			// only one CRL, so let's honor that just in case
 			i.Crl = append(i.Crl, t)
+		case nil:
+			// The old interface allowed for a null entry
+			// so let's leave that in place by leaving the array empty.
 		default:
-			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%s"`, t, t)))
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%v"`, t, t)))
 		}
 	}
 	if s, ok := intermediate["serial"]; ok {
@@ -73,7 +76,7 @@ func (i *Input) UnmarshalJSON(data []byte) error {
 				i.Serial = serial
 			}
 		default:
-			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "serial", got %T from value "%s"`, t, t)))
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "serial", got %T from value "%v"`, t, t)))
 		}
 	} else {
 		i.errs = append(i.errs, errors.New(`"serial" is a required field`))
@@ -88,7 +91,7 @@ func (i *Input) UnmarshalJSON(data []byte) error {
 				i.Date = date
 			}
 		default:
-			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "revocationData", got %T from value "%s"`, t, t)))
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "revocationData", got %T from value "%v"`, t, t)))
 		}
 	} else {
 		i.errs = append(i.errs, errors.New(`"revocationDate" is a required field`))
@@ -103,7 +106,7 @@ func (i *Input) UnmarshalJSON(data []byte) error {
 				i.Reason = reason
 			}
 		default:
-			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "revocationReason", got %T from value "%s"`, t, t)))
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "revocationReason", got %T from value "%v"`, t, t)))
 		}
 	} else {
 		i.Reason = utils.NOT_GIVEN

--- a/crlVerification/main.go
+++ b/crlVerification/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Input struct {
-	Crl    *string
+	Crl    []string
 	Serial *big.Int
 	Date   time.Time
 	Reason utils.RevocationReason
@@ -29,7 +29,7 @@ type Input struct {
 
 func NewInput() Input {
 	return Input{
-		Crl:    nil,
+		Crl:    make([]string, 0),
 		Serial: nil,
 		Date:   time.Time{},
 		Reason: utils.NOT_GIVEN,
@@ -38,43 +38,72 @@ func NewInput() Input {
 }
 
 func (i *Input) UnmarshalJSON(data []byte) error {
-	intermediate := make(map[string]string)
+	intermediate := make(map[string]interface{})
 	err := json.Unmarshal(data, &intermediate)
 	if err != nil {
 		i.errs = append(i.errs, err)
 		return nil
 	}
 	if c, ok := intermediate["crl"]; ok {
-		i.Crl = &c
-	} else {
-		i.Crl = nil
+		switch t := c.(type) {
+		case []interface{}:
+			for _, crlInterface := range t {
+				switch crl := crlInterface.(type) {
+				case string:
+					i.Crl = append(i.Crl, crl)
+				default:
+					i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%s"`, crl, crl)))
+				}
+			}
+		case string:
+			// The old interface allowed was built for
+			// only one CRL, so let's honor that just in case
+			i.Crl = append(i.Crl, t)
+		default:
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "crl", got %T from value "%s"`, t, t)))
+		}
 	}
 	if s, ok := intermediate["serial"]; ok {
-		serial, err := utils.BigIntFromHexString(s)
-		if err != nil {
-			i.errs = append(i.errs, err)
-		} else {
-			i.Serial = serial
+		switch t := s.(type) {
+		case string:
+			serial, err := utils.BigIntFromHexString(t)
+			if err != nil {
+				i.errs = append(i.errs, err)
+			} else {
+				i.Serial = serial
+			}
+		default:
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "serial", got %T from value "%s"`, t, t)))
 		}
 	} else {
 		i.errs = append(i.errs, errors.New(`"serial" is a required field`))
 	}
 	if d, ok := intermediate["revocationDate"]; ok {
-		t, err := utils.TimeFromString(d)
-		if err != nil {
-			i.errs = append(i.errs, err)
-		} else {
-			i.Date = t
+		switch t := d.(type) {
+		case string:
+			date, err := utils.TimeFromString(t)
+			if err != nil {
+				i.errs = append(i.errs, err)
+			} else {
+				i.Date = date
+			}
+		default:
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "revocationData", got %T from value "%s"`, t, t)))
 		}
 	} else {
 		i.errs = append(i.errs, errors.New(`"revocationDate" is a required field`))
 	}
 	if r, ok := intermediate["revocationReason"]; ok {
-		reason, err := utils.FromString(&r)
-		if err != nil {
-			i.errs = append(i.errs, err)
-		} else {
-			i.Reason = reason
+		switch t := r.(type) {
+		case string:
+			reason, err := utils.FromString(&t)
+			if err != nil {
+				i.errs = append(i.errs, err)
+			} else {
+				i.Reason = reason
+			}
+		default:
+			i.errs = append(i.errs, errors.New(fmt.Sprintf(`unexpected type for "revocationReason", got %T from value "%s"`, t, t)))
 		}
 	} else {
 		i.Reason = utils.NOT_GIVEN
@@ -114,13 +143,25 @@ func NewReturn() Return {
 }
 
 func Validate(i Input) Return {
-	crl, err := utils.CRLFromURL(i.Crl)
-	if err != nil {
+	if len(i.Crl) == 0 {
 		ret := NewReturn()
-		ret.Errors = append(ret.Errors, err)
+		ret.Errors = append(ret.Errors, utils.CRLNotGiven{})
 		return ret
 	}
-	return validate(i, crl)
+	allErrors := make([]error, 0)
+	for _, c := range i.Crl {
+		crl, err := utils.CRLFromURL(c)
+		switch err == nil {
+		case true:
+			return validate(i, crl)
+		case false:
+			log.Printf("failed to retrieve CRL from %s, err: %s", c, err)
+			allErrors = append(allErrors, err)
+		}
+	}
+	ret := NewReturn()
+	ret.Errors = append(ret.Errors, allErrors...)
+	return ret
 }
 
 func validate(i Input, crl *pkix.CertificateList) Return {

--- a/crlVerification/main_test.go
+++ b/crlVerification/main_test.go
@@ -9,8 +9,28 @@ import (
 	"testing"
 )
 
-const good = `{
+const goodSingleCRL = `{
 	"crl": "http://google.com/crl",
+	"serial": "0123456789abcdef",
+	"revocationDate": "2019/12/13",
+	"revocationReason": "(10) aACompromise"
+}`
+
+func TestInput_UnmarshalJSON_Single(t *testing.T) {
+	i := NewInput()
+	if err := json.Unmarshal([]byte(goodSingleCRL), &i); err != nil {
+		t.Fatal(err)
+	}
+	if len(i.errs) != 0 {
+		t.Fatal(i.errs)
+	}
+	if len(i.Crl) != 1 {
+		t.Fatalf("wanted 1 crl, got %d", len(i.Crl))
+	}
+}
+
+const good = `{
+	"crl": ["http://google.com/crl", "http://google.com/crl"],
 	"serial": "0123456789abcdef",
 	"revocationDate": "2019/12/13",
 	"revocationReason": "(10) aACompromise"
@@ -23,6 +43,9 @@ func TestInput_UnmarshalJSON(t *testing.T) {
 	}
 	if len(i.errs) != 0 {
 		t.Fatal(i.errs)
+	}
+	if len(i.Crl) != 2 {
+		t.Fatalf("wanted 2 crls, got %d", len(i.Crl))
 	}
 }
 
@@ -40,8 +63,8 @@ func TestInput_UnmarshalJSON_MissingCRL(t *testing.T) {
 	if len(i.errs) != 0 {
 		t.Fatal(i.errs)
 	}
-	if i.Crl != nil {
-		t.Fatalf("wanted nil CRL, got %v", i.Crl)
+	if len(i.Crl) != 0 {
+		t.Fatalf("wanted 0 CRLs, got %d", len(i.Crl))
 	}
 }
 

--- a/crlVerification/main_test.go
+++ b/crlVerification/main_test.go
@@ -24,8 +24,8 @@ func TestInput_UnmarshalJSON_Single(t *testing.T) {
 	if len(i.errs) != 0 {
 		t.Fatal(i.errs)
 	}
-	if len(i.Crl) != 1 {
-		t.Fatalf("wanted 1 crl, got %d", len(i.Crl))
+	if len(i.Crls) != 1 {
+		t.Fatalf("wanted 1 crl, got %d", len(i.Crls))
 	}
 }
 
@@ -44,8 +44,8 @@ func TestInput_UnmarshalJSON(t *testing.T) {
 	if len(i.errs) != 0 {
 		t.Fatal(i.errs)
 	}
-	if len(i.Crl) != 2 {
-		t.Fatalf("wanted 2 crls, got %d", len(i.Crl))
+	if len(i.Crls) != 2 {
+		t.Fatalf("wanted 2 crls, got %d", len(i.Crls))
 	}
 }
 
@@ -63,8 +63,8 @@ func TestInput_UnmarshalJSON_MissingCRL(t *testing.T) {
 	if len(i.errs) != 0 {
 		t.Fatal(i.errs)
 	}
-	if len(i.Crl) != 0 {
-		t.Fatalf("wanted 0 CRLs, got %d", len(i.Crl))
+	if len(i.Crls) != 0 {
+		t.Fatalf("wanted 0 CRLs, got %d", len(i.Crls))
 	}
 }
 

--- a/crlVerification/utils/crl.go
+++ b/crlVerification/utils/crl.go
@@ -40,16 +40,13 @@ func (c CRLFailedToParse) Error() string {
 	return fmt.Sprintf("%s failed to parse. error: %v", c.url, c.err)
 }
 
-func CRLFromURL(crlUrl *string) (*pkix.CertificateList, error) {
-	if crlUrl == nil {
-		return nil, CRLNotGiven{}
-	}
-	resp, err := http.Get(*crlUrl)
+func CRLFromURL(crlUrl string) (*pkix.CertificateList, error) {
+	resp, err := http.Get(crlUrl)
 	if err != nil {
-		return nil, CRLDownloadFailed{*crlUrl, err}
+		return nil, CRLDownloadFailed{crlUrl, err}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, CRLDownloadFailed{*crlUrl, errors.New(fmt.Sprintf("recieved  status code %v", resp.StatusCode))}
+		return nil, CRLDownloadFailed{crlUrl, errors.New(fmt.Sprintf("recieved  status code %v", resp.StatusCode))}
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -58,11 +55,11 @@ func CRLFromURL(crlUrl *string) (*pkix.CertificateList, error) {
 	}()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, CRLDownloadFailed{*crlUrl, err}
+		return nil, CRLDownloadFailed{crlUrl, err}
 	}
 	crl, err := x509.ParseCRL(body)
 	if err != nil {
-		return nil, CRLFailedToParse{*crlUrl, err}
+		return nil, CRLFailedToParse{crlUrl, err}
 	}
 	return crl, nil
 }


### PR DESCRIPTION
This change modifies the interface from accepting a string that is a single CRL URL to a list of CRL URLs to attempt. The application will resolve down the list, left to right, until a CRL succeeds to download. Download errors are discarded unless _all_ downloads fail, in which case all errors are returned for review purposes.