### PR TITLE
Resource Consumption Fix

### DIFF
--- a/kinto_integrity/Dockerfile
+++ b/kinto_integrity/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update
 RUN apt-get install xvfb libssl-dev ca-certificates libgtk-3-0 libdbus-glib-1-2 -y
 RUN apt-get clean
 
-COPY --from=buildStage /opt/target/release/kinto_integrity /opt/
+COPY --from=buildStage /opt/target/debug/kinto_integrity /opt/
 COPY --from=buildStage /opt/consultant /opt/
 
 ENTRYPOINT ["/opt/kinto_integrity"]

--- a/kinto_integrity/Dockerfile
+++ b/kinto_integrity/Dockerfile
@@ -6,7 +6,7 @@ FROM rustlang/rust@sha256:fdac35b8baebbc8bf1b99919271443688e9ef5656aeda52961edc2
 
 WORKDIR /opt
 COPY . .
-RUN cargo build --release
+RUN cargo build
 RUN wget https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz
 RUN tar zxf go1.13.4.linux-amd64.tar.gz
 RUN go/bin/go build -o consultant consultant.go

--- a/kinto_integrity/src/firefox/firefox/mod.rs
+++ b/kinto_integrity/src/firefox/firefox/mod.rs
@@ -159,7 +159,7 @@ impl Firefox {
     }
 
     pub fn update(&mut self, url: Url) -> Result<Option<()>> {
-        let _ = match FF_LOCK.lock() {
+        let _lock = match FF_LOCK.lock() {
             Ok(lock) => lock,
             Err(err) => return Err(Error::from(err.to_string()))
         };
@@ -175,7 +175,7 @@ impl Firefox {
     }
 
     pub fn force_update(&mut self, url: Url) -> Result<()> {
-        let _ = match FF_LOCK.lock() {
+        let _lock = match FF_LOCK.lock() {
             Ok(lock) => lock,
             Err(err) => return Err(Error::from(err.to_string()))
         };
@@ -188,7 +188,7 @@ impl Firefox {
     }
 
     pub fn update_cert_storage(&mut self) -> Result<()> {
-        let _ = match FF_LOCK.lock() {
+        let _lock = match FF_LOCK.lock() {
             Ok(lock) => lock,
             Err(err) => return Err(Error::from(err.to_string()))
         };


### PR DESCRIPTION
This change makes it such that Firefox Beta and Firefox Nightly are never executing at the same time to ensure that the host box doesn't run out of resources.

It all switches the build to a debug in order to speed up deployment. The actual application itself did not need such optimizations.