### PR TITLE
Update list of expected fields in IncludedCACertificateReportPEMCSV

### DIFF
--- a/capi/lib/ccadb/ccadb.go
+++ b/capi/lib/ccadb/ccadb.go
@@ -18,7 +18,7 @@ import (
 
 const ReportURL = "https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV"
 
-var headers = []string{"Owner", "Certificate Issuer Organization", "Certificate Issuer Organizational Unit", "Common Name or Certificate Name", "Certificate Serial Number", "SHA-256 Fingerprint", "Subject + SPKI SHA256", "Valid From [GMT]", "Valid To [GMT]", "Public Key Algorithm", "Signature Hash Algorithm", "Trust Bits", "EV Policy OID(s)", "Approval Bug", "NSS Release When First Included", "Firefox Release When First Included", "Test Website - Valid", "Test Website - Expired", "Test Website - Revoked", "Mozilla Applied Constraints", "Company Website", "Geographic Focus", "Certificate Policy (CP)", "Certification Practice Statement (CPS)", "Standard Audit", "BR Audit", "EV Audit", "Auditor", "Standard Audit Type", "Standard Audit Statement Dt", "PEM Info"}
+var headers = []string{"Owner", "Certificate Issuer Organization", "Certificate Issuer Organizational Unit", "Common Name or Certificate Name", "Certificate Serial Number", "SHA-256 Fingerprint", "Subject + SPKI SHA256", "Valid From [GMT]", "Valid To [GMT]", "Public Key Algorithm", "Signature Hash Algorithm", "Trust Bits", "Distrust for TLS After Date", "Distrust for S/MIME After Date", "EV Policy OID(s)", "Approval Bug", "NSS Release When First Included", "Firefox Release When First Included", "Test Website - Valid", "Test Website - Expired", "Test Website - Revoked", "Mozilla Applied Constraints", "Company Website", "Geographic Focus", "Certificate Policy (CP)", "Certification Practice Statement (CPS)", "Standard Audit", "BR Audit", "EV Audit", "Auditor", "Standard Audit Type", "Standard Audit Statement Dt", "PEM Info"}
 
 const (
 	Owner = iota
@@ -33,6 +33,8 @@ const (
 	PublicKeyAlgorithm
 	SignatureHashAlgorithm
 	TrustBits
+	DistrustForTLSAfterDate
+	DistrustForSMIMEAfterDate
 	EVPolicyOIDs
 	ApprovalBug
 	NSSReleaseWhenFirstIncluded


### PR DESCRIPTION
The `capi` tool's `/fromreport` endpoint downloads and processes https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV.  This endpoint has a hard-coded, ordered list of CSV header strings that it expects to find, and the tool will fail if any discrepancies are encountered when parsing the CSV.

This PR updates the expected CSV header strings in line with @WilsonKathleen's most recent changes (see https://www.mail-archive.com/dev-security-policy@lists.mozilla.org/msg13672.html), which causes `/fromreport` to work again.  :-)