### PR TITLE
Ignore CRL Distribution Point URLs in Root CA Certificates

### DIFF
--- a/capi/lib/revocation/crl/crl.go
+++ b/capi/lib/revocation/crl/crl.go
@@ -32,9 +32,13 @@ type CRL struct {
 
 func VerifyChain(chain []*x509.Certificate) [][]CRL {
 	crls := make([][]CRL, len(chain))
-	for i, cert := range chain {
+	if len(chain) == 1 {
+		return crls
+	}
+	for i, cert := range chain[:len(chain)-1] {
 		crls[i] = queryCRLs(cert)
 	}
+	crls[len(crls)-1] = make([]CRL, 0)
 	return crls
 }
 


### PR DESCRIPTION
Addresses #64.

The `VerifyChain` function in ocsp.go already ignores Root CA Certificates, so I basically just copied the logic from that function into the `VerifyChain` function in crl.go.