### PR TITLE
CRL and OCSP timeouts

### DIFF
--- a/capi/lib/certificateUtils/parseChain.go
+++ b/capi/lib/certificateUtils/parseChain.go
@@ -57,8 +57,8 @@ func GatherCertificateChain(subjectURL string) ([]*x509.Certificate, error) {
 	// This is very mandatory otherwise the HTTP package will vomit on revoked/expired certificates and return an error.
 	transport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := &http.Client{Transport: transport}
-	// You have ten seconds to comply.
-	client.Timeout = time.Duration(10 * time.Second)
+	// You have twenty seconds to comply.
+	client.Timeout = time.Duration(20 * time.Second)
 	req, err := http.NewRequest("GET", subjectURL, nil)
 	if err != nil {
 		return []*x509.Certificate{}, err

--- a/capi/lib/revocation/crl/crl.go
+++ b/capi/lib/revocation/crl/crl.go
@@ -84,7 +84,7 @@ func newCRL(serialNumber *big.Int, distributionPoint string) (crl CRL) {
 	req, err := http.NewRequest("GET", distributionPoint, nil)
 	req.Header.Add("X-Automated-Tool", "https://github.com/mozilla/CCADB-Tools/capi CCADB test website verification tool")
 	client := http.Client{}
-	client.Timeout = time.Duration(10 * time.Second)
+	client.Timeout = time.Duration(20 * time.Second)
 	raw, err := client.Do(req)
 	if err != nil {
 		crl.Error = errors.Wrapf(err, "failed to retrieve CRL from distribution point %v", distributionPoint).Error()

--- a/capi/lib/revocation/ocsp/ocsp.go
+++ b/capi/lib/revocation/ocsp/ocsp.go
@@ -191,7 +191,7 @@ func newOCSPResponse(certificate, issuer *x509.Certificate, responder string) (r
 	r.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0")
 	r.Header.Set("Content-Type", OCSPContentType)
 	client := http.Client{}
-	client.Timeout = time.Duration(10 * time.Second)
+	client.Timeout = time.Duration(20 * time.Second)
 	ret, err := client.Do(r)
 	if err != nil {
 		response.Status = BadResponse


### PR DESCRIPTION
These edits change the chain building and CRL/OCSP timeouts from 10 seconds to 20 seconds.