### PR TITLE
Switch to using the currently maintained Certlint repository

### DIFF
--- a/capi/Dockerfile
+++ b/capi/Dockerfile
@@ -35,7 +35,7 @@ RUN apk add glibc-2.29-r0.apk
 
 RUN apk add git build-base libffi-dev ruby-rdoc ruby-dev
 RUN gem install public_suffix simpleidn
-RUN cd /tmp && git clone https://github.com/awslabs/certlint.git && \
+RUN cd /tmp && git clone https://github.com/certlint/certlint.git && \
     cd certlint/ext && \
     ruby extconf.rb && \
     make


### PR DESCRIPTION
https://github.com/awslabs/certlint has been archived by the owner and is now read-only.  Some of its lints have now become stale due to changes in the BRs.

I maintain a fork at https://github.com/certlint/certlint.  Although I haven't yet been able to dedicate much time to adding new lints, I have been making sure that stale lints are updated to match the current BRs.