### PR TITLE
Update capi to use glibc-2.35-r1 alpine package

### DIFF
--- a/capi/Dockerfile
+++ b/capi/Dockerfile
@@ -30,8 +30,8 @@ ENV LD_LIBRARY_PATH /lib
 # x509lint needs glibc around as well as musl
 RUN apk --no-cache add ca-certificates wget
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
-RUN apk add glibc-2.29-r0.apk
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk
+RUN apk add glibc-2.35-r1.apk
 
 RUN apk add git build-base libffi-dev ruby-rdoc ruby-dev
 RUN gem install public_suffix simpleidn


### PR DESCRIPTION
This fixes Bugzilla [bug 1817339](https://bugzilla.mozilla.org/show_bug.cgi?id=1817339) by updating the capi Dockerfile to pull in the glibc-2.35-r1 alpine package. Newer releases of the alpine base image include nsswitch.conf, so this updated package removes that and allows the Docker image to build successfully.