### PR TITLE
Moving capi to a Debian base image

### DIFF
--- a/capi/Dockerfile
+++ b/capi/Dockerfile
@@ -6,14 +6,8 @@ FROM golang:latest AS buildStage
 
 WORKDIR /opt
 COPY . .
-# This is necessary to statically compile all
-# C libraries into the executable. Otherwise
-# the Alpine installation will fail out with
-# a "no such directory" when attempting to execute
-# the binary (it can't find the shared libs).
-ENV CGO_ENABLED=0
-RUN apt-get update
-RUN apt-get install -y libnss3-tools libssl-dev ruby-dev
+RUN apt update
+RUN apt install -y libnss3-tools libssl-dev ruby-dev
 RUN go build capi.go
 RUN git clone https://github.com/christopher-henderson/x509lint.git && \
     cd x509lint && \
@@ -22,24 +16,18 @@ RUN git clone https://github.com/christopher-henderson/x509lint.git && \
 #    cd x509lint && \
 #    make
 
-FROM alpine:latest
+FROM debian:latest
 
-RUN apk add --update nss-tools bash libressl musl libressl ruby
-ENV LD_LIBRARY_PATH /lib
+RUN apt update
+RUN apt install -y gcc g++ git libffi-dev libnss3-tools make ruby-dev ruby-sdoc
 
-# x509lint needs glibc around as well as musl
-RUN apk --no-cache add ca-certificates wget
-RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r1/glibc-2.35-r1.apk
-RUN apk add glibc-2.35-r1.apk
-
-RUN apk add git build-base libffi-dev ruby-rdoc ruby-dev
 RUN gem install public_suffix simpleidn
 RUN cd /tmp && git clone https://github.com/certlint/certlint.git && \
     cd certlint/ext && \
     ruby extconf.rb && \
     make
-RUN apk del git build-base libffi-dev ruby-rdoc ruby-dev
+
+RUN apt purge -y gcc g++ git libffi-dev make ruby-dev ruby-sdoc
 
 COPY --from=buildStage /opt/ /tmp/
 RUN mv /tmp/capi /opt/


### PR DESCRIPTION
@WilsonKathleen, I kept running into issues trying to get `/lintFromCertificateDetails` working on Alpine and even got the same errors using older images like Alpine:3.16. Due to the instability of trying to run this on Alpine, I tried moving it over to Debian:latest (bookworm) and it is now working. Benefits of this move are greater stability, cleaner builds, and more future-proof.

Please try this branch out and let me know if this works for you. Thanks!