### PR TITLE
updating Go to 1.21.3

### DIFF
--- a/EVChecker/go.mod
+++ b/EVChecker/go.mod
@@ -1,5 +1,5 @@
 module github.com/mozilla/CCADB-Tools
 
-go 1.21.1
+go 1.21.3
 
 require github.com/pkg/errors v0.9.1

--- a/capi/go.mod
+++ b/capi/go.mod
@@ -18,4 +18,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.21.1
+go 1.21.3

--- a/certdataDiffCCADB/go.mod
+++ b/certdataDiffCCADB/go.mod
@@ -1,6 +1,6 @@
 module github.com/mozilla/CCADB-Tools/certdataDiffCCADB
 
-go 1.21.1
+go 1.21.3
 
 require github.com/throttled/throttled v2.2.5+incompatible
 

--- a/certificate/go.mod
+++ b/certificate/go.mod
@@ -1,6 +1,6 @@
 module CCADB-Tools/certificate
 
-go 1.21.1
+go 1.21.3
 
 require (
 	github.com/gin-contrib/logger v0.2.6

--- a/crlVerification/go.mod
+++ b/crlVerification/go.mod
@@ -1,5 +1,5 @@
 module github.com/mozilla/CCADB-Tools/crlVerification
 
-go 1.21.1
+go 1.21.3
 
 require github.com/pkg/errors v0.9.1

--- a/evReadiness/go.mod
+++ b/evReadiness/go.mod
@@ -1,6 +1,6 @@
 module CCADB-Tools/evReadiness
 
-go 1.21.1
+go 1.21.3
 
 require (
 	github.com/gin-gonic/gin v1.9.1

--- a/oneCRLDiffCCADB/go.mod
+++ b/oneCRLDiffCCADB/go.mod
@@ -1,5 +1,5 @@
 module github.com/mozilla/CCADB-Tools/oneCRLDiffCCADB
 
-go 1.21.1
+go 1.21.3
 
 require github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d

--- a/oneCRLViewer/go.mod
+++ b/oneCRLViewer/go.mod
@@ -1,6 +1,6 @@
 module github.com/mozilla/CCADB-Tools/oneCRLViewer
 
-go 1.21.1
+go 1.21.3
 
 require (
 	github.com/gocarina/gocsv v0.0.0-20230616125104-99d496ca653d


### PR DESCRIPTION
@WilsonKathleen, this is a security update for anything using Go's net/http package. It fixes the HTTP/2 rapid stream resets vulnerability:
- https://github.com/golang/go/issues/63427
- https://github.com/golang/go/issues/63417
- https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo?pli=1

Each of these images will need to be rebuilt to reflect the changes.